### PR TITLE
Updated spdlog dependency.

### DIFF
--- a/cmake/Log_dependencies.cmake
+++ b/cmake/Log_dependencies.cmake
@@ -18,7 +18,7 @@ FetchContent_Declare( catch-adapter
 
 FetchContent_Declare( spdlog
     GIT_REPOSITORY  https://github.com/gabime/spdlog.git
-    GIT_TAG         a51b4856377a71f81b6d74b9af459305c4c644f8
+    GIT_TAG         v0.9.0
     GIT_SHALLOW     TRUE
     )
 set( SPDLOG_BUILD_TESTING CACHE BOOL OFF )


### PR DESCRIPTION
Old dependency ceased working in FetchContent.  Using v0.9.0 tag, despite being an older vintage, seems to work just fine.  Checked in both the tests here and in ENDFtk.  Tags with v1.x.x do not work without changes here.